### PR TITLE
[Lv.2] 7번 N+1 문제 해결

### DIFF
--- a/src/main/java/org/example/expert/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/org/example/expert/domain/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package org.example.expert.domain.comment.repository;
 
 import org.example.expert.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +10,7 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    @Query("SELECT c FROM Comment c JOIN c.user WHERE c.todo.id = :todoId")
+    @EntityGraph(attributePaths = {"user"})
+    @Query("SELECT c FROM Comment c WHERE c.todo.id = :todoId")
     List<Comment> findByTodoIdWithUser(@Param("todoId") Long todoId);
 }


### PR DESCRIPTION
- `CommentController` 클래스의 `getComments()` API를 호출할 때 N+1 문제가 발생하고 있어요. N+1 문제란, 데이터베이스 쿼리 성능 저하를 일으키는 대표적인 문제 중 하나로, 특히 연관된 엔티티를 조회할 때 발생해요.
- 해당 문제가 발생하지 않도록 코드를 수정해주세요.