### PR TITLE
[Lv.3] 10번 QueryDSL을 사용하여 검색 기능 만들기 구현

### DIFF
--- a/src/main/java/org/example/expert/domain/todo/controller/TodoController.java
+++ b/src/main/java/org/example/expert/domain/todo/controller/TodoController.java
@@ -4,8 +4,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.expert.domain.common.dto.AuthUser;
 import org.example.expert.domain.todo.dto.request.TodoSaveRequest;
+import org.example.expert.domain.todo.dto.request.TodoSearchCondition;
 import org.example.expert.domain.todo.dto.response.TodoResponse;
 import org.example.expert.domain.todo.dto.response.TodoSaveResponse;
+import org.example.expert.domain.todo.dto.response.TodoSearchResponse;
 import org.example.expert.domain.todo.service.TodoService;
 import org.springframework.data.domain.Page;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -45,5 +47,14 @@ public class TodoController {
     @GetMapping("/todos/{todoId}")
     public ResponseEntity<TodoResponse> getTodo(@PathVariable long todoId) {
         return ResponseEntity.ok(todoService.getTodo(todoId));
+    }
+
+    @GetMapping("/todos/search")
+    public ResponseEntity<Page<TodoSearchResponse>> searchTodos(
+            @ModelAttribute TodoSearchCondition condition,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ResponseEntity.ok(todoService.searchTodos(condition, page, size));
     }
 }

--- a/src/main/java/org/example/expert/domain/todo/dto/request/TodoSearchCondition.java
+++ b/src/main/java/org/example/expert/domain/todo/dto/request/TodoSearchCondition.java
@@ -1,0 +1,30 @@
+package org.example.expert.domain.todo.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class TodoSearchCondition {
+
+    private String title;
+    private String managerNickname;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
+
+    public LocalDateTime getStartDateTime() {
+        return (this.startDate != null) ? startDate.atStartOfDay() : null;
+    }
+
+    public LocalDateTime getEndDateTime() {
+        return (endDate != null) ? endDate.atTime(23, 59) : null;
+    }
+}

--- a/src/main/java/org/example/expert/domain/todo/dto/response/TodoSearchResponse.java
+++ b/src/main/java/org/example/expert/domain/todo/dto/response/TodoSearchResponse.java
@@ -1,0 +1,19 @@
+package org.example.expert.domain.todo.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class TodoSearchResponse {
+
+    private final Long id;
+    private final String title;
+    private final Long countOfManagers;
+    private final Long countOfComments;
+
+    public TodoSearchResponse(Long id, String title, Long countOfManagers, Long countOfComments) {
+        this.id = id;
+        this.title = title;
+        this.countOfManagers = countOfManagers;
+        this.countOfComments = countOfComments;
+    }
+}

--- a/src/main/java/org/example/expert/domain/todo/repository/TodoQueryRepository.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoQueryRepository.java
@@ -1,6 +1,10 @@
 package org.example.expert.domain.todo.repository;
 
+import org.example.expert.domain.todo.dto.request.TodoSearchCondition;
+import org.example.expert.domain.todo.dto.response.TodoSearchResponse;
 import org.example.expert.domain.todo.entity.Todo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
@@ -8,5 +12,5 @@ import java.util.Optional;
 public interface TodoQueryRepository {
 
     Optional<Todo> findTodoByIdWithUser(@Param("todoId") Long todoId);
-
+    Page<TodoSearchResponse> searchTodos(TodoSearchCondition condition, Pageable pageable);
 }

--- a/src/main/java/org/example/expert/domain/todo/repository/TodoQueryRepositoryImpl.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoQueryRepositoryImpl.java
@@ -1,12 +1,26 @@
 package org.example.expert.domain.todo.repository;
 
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.example.expert.domain.comment.entity.QComment;
+import org.example.expert.domain.manager.entity.QManager;
+import org.example.expert.domain.todo.dto.request.TodoSearchCondition;
+import org.example.expert.domain.todo.dto.response.TodoSearchResponse;
 import org.example.expert.domain.todo.entity.QTodo;
 import org.example.expert.domain.todo.entity.Todo;
 import org.example.expert.domain.user.entity.QUser;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.util.StringUtils;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+
+import static org.example.expert.domain.todo.entity.QTodo.todo;
 
 @RequiredArgsConstructor
 public class TodoQueryRepositoryImpl implements TodoQueryRepository {
@@ -15,7 +29,7 @@ public class TodoQueryRepositoryImpl implements TodoQueryRepository {
 
     @Override
     public Optional<Todo> findTodoByIdWithUser(Long todoId) {
-        QTodo qTodo = QTodo.todo;
+        QTodo qTodo = todo;
         QUser qUser = QUser.user;
 
         Todo todo = queryFactory
@@ -26,5 +40,75 @@ public class TodoQueryRepositoryImpl implements TodoQueryRepository {
                 .fetchOne();
 
         return Optional.ofNullable(todo);
+    }
+
+    @Override
+    public Page<TodoSearchResponse> searchTodos(TodoSearchCondition condition, Pageable pageable) {
+        QTodo qTodo = todo;
+        QManager qManager = QManager.manager;
+        QUser qUser = QUser.user;
+        QComment qComment = QComment.comment;
+
+        List<TodoSearchResponse> results = queryFactory
+                .select(Projections.constructor(
+                        TodoSearchResponse.class,
+                        qTodo.id,
+                        qTodo.title,
+                        qManager.countDistinct(),
+                        qComment.countDistinct()
+                ))
+                .from(qTodo)
+                .leftJoin(qTodo.managers, qManager)
+                .leftJoin(qManager.user, qUser)
+                .leftJoin(qTodo.comments, qComment)
+                .where(
+                        titleContains(condition.getTitle()),
+                        managerNicknameContains(condition.getManagerNickname()),
+                        createdAtBetween(condition.getStartDateTime(), condition.getEndDateTime())
+                )
+                .groupBy(qTodo.id)
+                .orderBy(qTodo.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = Optional.ofNullable(
+                queryFactory
+                        .select(qTodo.countDistinct())
+                        .from(qTodo)
+                        .leftJoin(qTodo.managers, qManager)
+                        .leftJoin(qManager.user, qUser)
+                        .where(
+                                titleContains(condition.getTitle()),
+                                managerNicknameContains(condition.getManagerNickname()),
+                                createdAtBetween(condition.getStartDateTime(), condition.getEndDateTime())
+                        )
+                        .fetchOne()
+        ).orElse(0L);
+
+        return new PageImpl<>(results, pageable, total);
+    }
+
+    private BooleanExpression titleContains(String title) {
+        return StringUtils.hasText(title) ? todo.title.contains(title) : null;
+    }
+
+    private BooleanExpression managerNicknameContains(String nickname) {
+        return StringUtils.hasText(nickname)
+                ? QManager.manager.user.nickname.contains(nickname)
+                : null;
+    }
+
+    private BooleanExpression createdAtBetween(LocalDateTime from, LocalDateTime to) {
+        BooleanExpression condition = null;
+
+        if (from != null) {
+            condition = todo.createdAt.goe(from);
+        }
+        if (to != null) {
+            condition = (condition != null) ? condition.and(todo.createdAt.loe(to)) : todo.createdAt.loe(to);
+        }
+
+        return condition;
     }
 }

--- a/src/main/java/org/example/expert/domain/todo/service/TodoService.java
+++ b/src/main/java/org/example/expert/domain/todo/service/TodoService.java
@@ -5,8 +5,10 @@ import org.example.expert.client.WeatherClient;
 import org.example.expert.domain.common.dto.AuthUser;
 import org.example.expert.domain.common.exception.InvalidRequestException;
 import org.example.expert.domain.todo.dto.request.TodoSaveRequest;
+import org.example.expert.domain.todo.dto.request.TodoSearchCondition;
 import org.example.expert.domain.todo.dto.response.TodoResponse;
 import org.example.expert.domain.todo.dto.response.TodoSaveResponse;
+import org.example.expert.domain.todo.dto.response.TodoSearchResponse;
 import org.example.expert.domain.todo.entity.Todo;
 import org.example.expert.domain.todo.repository.TodoRepository;
 import org.example.expert.domain.user.dto.response.UserResponse;
@@ -97,5 +99,10 @@ public class TodoService {
                 todo.getCreatedAt(),
                 todo.getModifiedAt()
         );
+    }
+
+    public Page<TodoSearchResponse> searchTodos(TodoSearchCondition condition, int page, int size) {
+        Pageable pageable = PageRequest.of(page-1, size);
+        return todoRepository.searchTodos(condition, pageable);
     }
 }


### PR DESCRIPTION
- 새로운 API로 만들어주세요.
- 검색 조건은 다음과 같아요.
    - 검색 키워드로 일정의 제목을 검색할 수 있어요.
        - 제목은 부분적으로 일치해도 검색이 가능해요.
    - 일정의 생성일 범위로 검색할 수 있어요.
        - 일정을 생성일 최신순으로 정렬해주세요.
    - 담당자의 닉네임으로도 검색이 가능해요.
        - 닉네임은 부분적으로 일치해도 검색이 가능해요.
- 다음의 내용을 포함해서 검색 결과를 반환해주세요.
    - 일정에 대한 모든 정보가 아닌, 제목만 넣어주세요.
    - 해당 일정의 담당자 수를 넣어주세요.
    - 해당 일정의 총 댓글 개수를 넣어주세요.