### PR TITLE
[Lv.3] 11번 Transaction 심화 구현

### DIFF
--- a/src/main/java/org/example/expert/domain/log/consts/LogMessage.java
+++ b/src/main/java/org/example/expert/domain/log/consts/LogMessage.java
@@ -1,0 +1,5 @@
+package org.example.expert.domain.log.consts;
+
+public class LogMessage {
+    public static final String MANAGER_REGISTER_MESSAGE = "User(userId={0}) requested to assign user(userId={1}) as a manager for todo(todoId={2}).";
+}

--- a/src/main/java/org/example/expert/domain/log/entity/Log.java
+++ b/src/main/java/org/example/expert/domain/log/entity/Log.java
@@ -1,0 +1,40 @@
+package org.example.expert.domain.log.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.expert.domain.common.entity.Timestamped;
+import org.example.expert.domain.log.enums.RequestType;
+import org.example.expert.domain.user.entity.User;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "log")
+public class Log extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private Long targetId;
+
+    @Enumerated(EnumType.STRING)
+    private RequestType requestType;
+
+    private String message;
+
+    @Builder
+    public Log(Long userId, Long targetId, RequestType requestType, String message) {
+        this.userId = userId;
+        this.targetId = targetId;
+        this.requestType = requestType;
+        this.message = message;
+    }
+}

--- a/src/main/java/org/example/expert/domain/log/enums/RequestType.java
+++ b/src/main/java/org/example/expert/domain/log/enums/RequestType.java
@@ -1,0 +1,5 @@
+package org.example.expert.domain.log.enums;
+
+public enum RequestType {
+    TODO_MANAGER_REGISTER
+}

--- a/src/main/java/org/example/expert/domain/log/repository/LogRepository.java
+++ b/src/main/java/org/example/expert/domain/log/repository/LogRepository.java
@@ -1,0 +1,7 @@
+package org.example.expert.domain.log.repository;
+
+import org.example.expert.domain.log.entity.Log;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LogRepository extends JpaRepository<Log, Long> {
+}

--- a/src/main/java/org/example/expert/domain/log/service/LogService.java
+++ b/src/main/java/org/example/expert/domain/log/service/LogService.java
@@ -1,0 +1,32 @@
+package org.example.expert.domain.log.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.expert.domain.log.consts.LogMessage;
+import org.example.expert.domain.log.entity.Log;
+import org.example.expert.domain.log.enums.RequestType;
+import org.example.expert.domain.log.repository.LogRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.text.MessageFormat;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.REQUIRES_NEW)
+public class LogService {
+
+    private final LogRepository logRepository;
+
+    public void saveManagerRegisterLog(Long userId, Long managerUserId, Long todoId) {
+        String message = MessageFormat.format(LogMessage.MANAGER_REGISTER_MESSAGE, userId, managerUserId, todoId);
+        logRepository.save(
+                Log.builder()
+                        .userId(userId)
+                        .targetId(todoId)
+                        .requestType(RequestType.TODO_MANAGER_REGISTER)
+                        .message(message)
+                        .build()
+        );
+    }
+}

--- a/src/main/java/org/example/expert/domain/manager/service/ManagerService.java
+++ b/src/main/java/org/example/expert/domain/manager/service/ManagerService.java
@@ -3,6 +3,8 @@ package org.example.expert.domain.manager.service;
 import lombok.RequiredArgsConstructor;
 import org.example.expert.domain.common.dto.AuthUser;
 import org.example.expert.domain.common.exception.InvalidRequestException;
+import org.example.expert.domain.log.enums.RequestType;
+import org.example.expert.domain.log.service.LogService;
 import org.example.expert.domain.manager.dto.request.ManagerSaveRequest;
 import org.example.expert.domain.manager.dto.response.ManagerResponse;
 import org.example.expert.domain.manager.dto.response.ManagerSaveResponse;
@@ -28,9 +30,12 @@ public class ManagerService {
     private final ManagerRepository managerRepository;
     private final UserRepository userRepository;
     private final TodoRepository todoRepository;
+    private final LogService logService;
 
     @Transactional
     public ManagerSaveResponse saveManager(AuthUser authUser, long todoId, ManagerSaveRequest managerSaveRequest) {
+        logService.saveManagerRegisterLog(authUser.getId(), managerSaveRequest.getManagerUserId(), todoId);
+
         // 일정을 만든 유저
         User user = User.fromAuthUser(authUser);
         Todo todo = todoRepository.findById(todoId)


### PR DESCRIPTION
👉 매니저 등록 요청 시 로그를 남기고 싶어요!
`@Transactional`의 옵션 중 하나를 활용하여 매니저 등록과 로그 기록이 각각 독립적으로 처리될 수 있도록 해봅시다.

- 매니저 등록 요청을 기록하는 로그 테이블을 만들어주세요.
    - DB 테이블명: `log`
- 매니저 등록과는 별개로 로그 테이블에는 항상 요청 로그가 남아야 해요.
    - 매니저 등록은 실패할 수 있지만, 로그는 반드시 저장되어야 합니다.
    - 로그 생성 시간은 반드시 필요합니다.
    - 그 외 로그에 들어가는 내용은 원하는 정보를 자유롭게 넣어주세요.